### PR TITLE
Fix a Linux crash on mts dtor when no MTS present

### DIFF
--- a/Client/libMTSClient.cpp
+++ b/Client/libMTSClient.cpp
@@ -67,8 +67,8 @@ struct mtsclientglobal
         UseMultiChannelTuning           =(mts_bc)   dlsym(handle,"MTS_UseMultiChannelTuning");
         GetScaleName                    =(mts_pcc)  dlsym(handle,"MTS_GetScaleName");
     }
-    virtual ~mtsclientglobal() {dlclose(handle);}
-    void *handle;
+    virtual ~mtsclientglobal() {if(handle) dlclose(handle);}
+    void *handle = nullptr;
 #endif
 };
 


### PR DESCRIPTION
If MTS isn't installed on the machine and you destruct
an mtsclientglobal, dont' core dump by dlclosing null.