### PR TITLE
Fix a crash on exit

### DIFF
--- a/Client/libMTSClient.cpp
+++ b/Client/libMTSClient.cpp
@@ -81,7 +81,7 @@ struct MTSClient
         for (int i=0;i<128;i++) retuning[i]=440.*pow(2.,(i-69.)/12.);
         if (global.RegisterClient) global.RegisterClient((void*)this);
     }
-    ~MTSClient() {if (global.DeregisterClient) global.DeregisterClient((void*)this);}
+    ~MTSClient() {if (hasMaster() && global.DeregisterClient) global.DeregisterClient((void*)this);}
     bool hasMaster() {return global.isOnline();}
     inline double freq(char midinote,char midichannel)
     {


### PR DESCRIPTION
If Surge and MTSMaster were loaded into Hosting AU with MTSMaster
"after" surge in the track list, there was a crash on exit. The
crash on exit was caused by Deregister not checking if the master
was online, and HostingAU reaping the MTSMaster before the Surge
instance. Fix it by guarding the deregister.